### PR TITLE
Use callbacks instead of Promises for pre/post hooks to make safari h…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sociare",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "Super simple customizable share buttons with counts.",
   "homepage": "https://github.com/Globobeet/sociare",
   "main": "lib/index.js",

--- a/readme.md
+++ b/readme.md
@@ -93,7 +93,7 @@ In any of the button configuration options (both default and button-specific), t
 | `buttonClass` | String | `"sociare sociare-{network}"` | Default button classes |
 | `buttonAttrs` | Object | `{}` | Additional attributes on button elements. Keys map to attribute names, values to attribute values |
 | `buttonTemplate` | String | `"Share on {network} - {count}"` | Default button template |
-| `buttonPreHook` | Function | `undefined` | Function to call immediately before opening popup. If is a rejecting promise, or throws an error, will prevent popup from opening. |
+| `buttonPreHook` | Function | `undefined` | Function to call immediately before opening popup. Is passed a callback, which will prevent popup from opening if called with an error. Async functions run the risk of resulting in a blocked popup.  |
 | `buttonPostHook` | Function | `undefined` | Function to call immediately after opening popup. |
 | `buttons` | Array[String/Object] | `[]` | Buttons to be rendered. Can be a string of the network name to use default configuration, or a [button-specific configuration](#button-specific-configuration) object. Available networks are `"facebook"`, `"twitter"`, `"pinterest"`, `"linkedin"`, and `"googleplus"` |
 | `twitterExtras` | Object | `{}` | Default extra options for Twitter buttons. See [Twitter Extras](#twitter-extras) for full list of options.
@@ -113,8 +113,8 @@ Instead of just passing the network name as a string, you can fine-tune any butt
 | `class` | String | Button element classes |
 | `attrs` | Object | Additional attributes on button element. Keys map to attribute names, values to attribute values |
 | `template` | String | String template for innerHTML of button element |
-| `preHook` | Function |  Function to call immediately before opening popup. If is a rejecting promise, or throws an error, will prevent popup from opening. |
-| `postHook` | Function |  Function to call immediately after opening popup. | 
+| `preHook` | Function | Function to call immediately before opening popup. Is passed a callback, which will prevent popup from opening if called with an error. Async functions run the risk of resulting in a blocked popup. |
+| `postHook` | Function | Function to call immediately after opening popup. |
 | `extras` | Object | Additional network options (only available in twitter, pinterest, and linkedin types). See [Extras](#extras)
 
 

--- a/src/services/abstract.js
+++ b/src/services/abstract.js
@@ -98,24 +98,25 @@ export default class AbstractService {
 
     // Bind click event
     this.elem.onclick = (event) => {
-      let popup_options = 'status=no,resizable=yes,toolbar=no,menubar=no,scrollbars=no,location=no,directories=no,width=600,height=600';
+      let popup_options = 'status=no,resizable=yes,toolbar=no,menubar=no,scrollbars=no,location=no,directories=no,width=600,height=600',
+          noop = function (cb) { if (cb) { return cb(); } },
+          pre = this.options.preHook || noop,
+          post = this.options.postHook || noop;
 
       // Prevent bubbling
       event.stopPropagation();
 
-      return Promise.resolve()
-        .then(this.options.preHook)
-        .then(() => {
-          // Open the share popup
-          window.open(this.popupUrl, this.name, popup_options);
+      pre(function (err) {
+        if (err) { return console.error('[Sociare Error]', err); }
 
-          // Add 1 to the count
-          this.count = this[$count] + 1;
-        })
-        .then(this.options.postHook)
-        .catch(err => {
-          console.error('[Sociare Error]', err);
-        });
+        // Open the share popup
+        window.open(this.popupUrl, this.name, popup_options);
+
+        // Add 1 to the count
+        this.count = this[$count] + 1;
+
+        post();
+      }.bind(this));
     };
 
     // Mark it as rendered

--- a/test/services/abstract.spec.js
+++ b/test/services/abstract.spec.js
@@ -202,7 +202,9 @@ describe('Sociare', () => {
           },
           template: 'Testing {network} - {count}'
         }]
-      }, service, elem, open, event;
+      },
+      t = 100,
+      service, elem, open, event;
 
       beforeEach(() => {
         service = new TestService(config);
@@ -214,46 +216,80 @@ describe('Sociare', () => {
 
       afterEach(() => { open.restore(); });
 
-      it('should open a popup', () => {
-        return elem.onclick(event).then(() => {
-            expect(open).to.have.been.calledOnce;
-            expect(open).to.have.been.calledWith('http://test.com', 'test');
-        });
+      it('should open a popup', done => {
+        elem.onclick(event);
+
+        setTimeout(() => {
+          expect(open).to.have.been.calledOnce;
+          expect(open).to.have.been.calledWith('http://test.com', 'test');
+          done();
+        }, t);
       });
 
-      it('should increase the count by 1', () => {
-        return elem.onclick(event).then(() => {
-            expect(service.count).to.equal(6);
-        });
+      it('should increase the count by 1', done => {
+        elem.onclick(event);
+
+        setTimeout(() => {
+          expect(service.count).to.equal(6);
+          done();
+        }, t);
       });
 
-      it('should re-render the button', () => {
-        return elem.onclick(event).then(() => {
+      it('should re-render the button', done => {
+        elem.onclick(event);
+
+        setTimeout(() => {
           expect(elem.innerHTML).to.equal('Testing test - 6');
-        });
+          done();
+        }, t);
       });
 
       describe('with a pre-hook', () => {
         let pre;
         beforeEach(() => {
-          pre = sinon.stub().returns(Promise.resolve());
+          pre = sinon.stub().callsArg(0);
           config.buttonPreHook = pre;
           service = new TestService(config);
           elem = service.generateButton();
         });
 
-        it('should run the pre-hook first', () => {
-          return elem.onclick(event).then(() => {
+        it('should run the pre-hook first', done => {
+          elem.onclick(event);
+
+          setTimeout(() => {
             expect(pre).to.have.been.calledOnce;
             expect(pre).to.have.been.calledBefore(open);
-          });
+            done();
+          }, t);
         });
 
-        it('should prevent the pop-up if it errors', () => {
-          pre.returns(Promise.reject('failure'));
+        describe('if it errors', () => {
+          let log;
 
-          return elem.onclick(event).then(() => {
-            expect(open).to.not.have.been.called;
+          beforeEach(() => {
+            pre.callsArgWith(0, 'failure');
+            log = sinon.stub(console, 'error');
+          });
+
+          afterEach(() => { log.restore(); });
+
+          it('should log the error', done => {
+            elem.onclick(event);
+
+            setTimeout(() => {
+              expect(log).to.have.been.calledOnce;
+              expect(log.args[0][1]).to.equal('failure');
+              done();
+            }, t);
+          });
+
+          it('should prevent the pop-up if it errors', done => {
+            elem.onclick(event);
+
+            setTimeout(() => {
+              expect(open).to.not.have.been.called;
+              done();
+            }, t);
           });
         });
       });
@@ -261,21 +297,24 @@ describe('Sociare', () => {
       describe('with a post-hook', () => {
         let pre, post;
         beforeEach(() => {
-          pre = sinon.stub().returns(Promise.resolve());
-          post = sinon.stub().returns(Promise.resolve());
+          pre = sinon.stub().callsArg(0);
+          post = sinon.stub();
           config.buttonPreHook = pre;
           config.buttonPostHook = post;
           service = new TestService(config);
           elem = service.generateButton();
         });
 
-        it('should run the post-hook last', () => {
-          return elem.onclick(event).then(() => {
+        it('should run the post-hook last', done => {
+          elem.onclick(event);
+
+          setTimeout(() => {
             expect(pre).to.have.been.calledOnce;
             expect(open).to.have.been.calledOnce;
             expect(post).to.have.been.calledOnce;
             expect(post).to.have.been.calledAfter(open);
-          });
+            done();
+          }, t);
         });
       });
     });


### PR DESCRIPTION
Safari blocks the share popup when handling the hooks with Promises (even when no async delays are occurring). Fixed this by falling back to a simple callback system (ugh).
